### PR TITLE
Allow using methods as Rpc targets instead of needing to define `call`. 

### DIFF
--- a/examples/calculator/server.py
+++ b/examples/calculator/server.py
@@ -1,25 +1,23 @@
 import asyncio
-from typing import Any
 
-from capnweb.error import RpcError
 from capnweb.server import Server, ServerConfig
 from capnweb.types import RpcTarget
 
 
 class Calculator(RpcTarget):
-    async def call(self, method: str, args: list[Any]) -> Any:
-        match method:
-            case "add":
-                return args[0] + args[1]
-            case "subtract":
-                return args[0] - args[1]
-            case _:
-                msg = f"Method {method} not found"
-                raise RpcError.not_found(msg)
+    """Calculator service using automatic method dispatch.
 
-    async def get_property(self, property: str) -> Any:
-        msg = "Property access not implemented"
-        raise RpcError.not_found(msg)
+    Methods are automatically exposed as RPC endpoints.
+    No need for manual call() implementation with match/case.
+    """
+
+    async def add(self, a: int, b: int) -> int:
+        """Add two numbers."""
+        return a + b
+
+    async def subtract(self, a: int, b: int) -> int:
+        """Subtract b from a."""
+        return a - b
 
 
 async def main() -> None:

--- a/src/capnweb/types.py
+++ b/src/capnweb/types.py
@@ -2,20 +2,40 @@
 
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
+import inspect
+from abc import ABC
 from typing import Any, Protocol
 
 
 class RpcTarget(ABC):
-    """Abstract base class for RPC capability implementations.
+    """Base class for RPC capability implementations.
 
-    Capabilities are objects that can receive method calls and property access
-    over the RPC protocol.
+    Methods defined on subclasses automatically become RPC-callable,
+    similar to the Cloudflare capnweb API. Methods starting with underscore
+    are considered private and not exposed over RPC.
+
+    Example:
+        class Calculator(RpcTarget):
+            async def add(self, a: int, b: int) -> int:
+                return a + b
+
+            async def subtract(self, a: int, b: int) -> int:
+                return a - b
+
+            def _private_helper(self):  # Not exposed over RPC
+                pass
+
+    For advanced use cases, you can override `call()` and `get_property()`
+    to implement custom dispatch logic (e.g., for backward compatibility
+    with match/case dispatch patterns).
     """
 
-    @abstractmethod
     async def call(self, method: str, args: list[Any]) -> Any:
         """Call a method on this capability.
+
+        By default, this looks up the method by name on the instance
+        and calls it with the provided arguments. Methods starting with
+        underscore are not accessible over RPC.
 
         Args:
             method: The method name to call
@@ -25,13 +45,38 @@ class RpcTarget(ABC):
             The result of the method call
 
         Raises:
-            RpcError: If the method call fails
+            RpcError: If the method is not found or call fails
         """
-        ...
+        from .error import RpcError
 
-    @abstractmethod
+        # Don't allow private methods
+        if method.startswith("_"):
+            raise RpcError.not_found(f"Method {method} not found")
+
+        # Look up the method
+        if not hasattr(self, method):
+            raise RpcError.not_found(f"Method {method} not found")
+
+        method_obj = getattr(self, method)
+
+        # Check if it's callable
+        if not callable(method_obj):
+            raise RpcError.not_found(f"Method {method} not found")
+
+        # Call the method
+        result = method_obj(*args)
+
+        # Handle async methods
+        if inspect.iscoroutine(result):
+            return await result
+
+        return result
+
     async def get_property(self, property: str) -> Any:
         """Get a property from this capability.
+
+        By default, this looks up the attribute by name on the instance.
+        Attributes starting with underscore are not accessible over RPC.
 
         Args:
             property: The property name to access
@@ -40,9 +85,25 @@ class RpcTarget(ABC):
             The property value
 
         Raises:
-            RpcError: If the property access fails
+            RpcError: If the property is not found or access fails
         """
-        ...
+        from .error import RpcError
+
+        # Don't allow private properties
+        if property.startswith("_"):
+            raise RpcError.not_found(f"Property {property} not found")
+
+        # Look up the property
+        if not hasattr(self, property):
+            raise RpcError.not_found(f"Property {property} not found")
+
+        value = getattr(self, property)
+
+        # Don't expose methods as properties
+        if callable(value):
+            raise RpcError.not_found(f"Property {property} not found")
+
+        return value
 
 
 class Transport(Protocol):

--- a/tests/test_automatic_dispatch.py
+++ b/tests/test_automatic_dispatch.py
@@ -1,0 +1,314 @@
+"""Tests for automatic method dispatch in RpcTarget.
+
+This test suite validates the new automatic method dispatch API where
+methods on RpcTarget subclasses are automatically exposed as RPC endpoints.
+"""
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from capnweb import Client, ClientConfig, RpcError, RpcTarget, Server, ServerConfig
+
+
+class AutoCalculator(RpcTarget):
+    """Calculator using automatic method dispatch."""
+
+    async def add(self, a: int, b: int) -> int:
+        """Add two numbers."""
+        return a + b
+
+    async def subtract(self, a: int, b: int) -> int:
+        """Subtract b from a."""
+        return a - b
+
+    def multiply(self, a: int, b: int) -> int:
+        """Multiply two numbers (sync method)."""
+        return a * b
+
+    async def divide(self, a: float, b: float) -> float:
+        """Divide a by b."""
+        if b == 0:
+            msg = "Cannot divide by zero"
+            raise ValueError(msg)
+        return a / b
+
+    def _private_method(self) -> str:
+        """Private method - should not be accessible via RPC."""
+        return "secret"
+
+
+class StatefulService(RpcTarget):
+    """Service with state and properties."""
+
+    def __init__(self):
+        self.count = 0
+        self.name = "StatefulService"
+        self._internal_state = "hidden"
+
+    async def set(self, count: int) -> int:
+        self.count = count
+        return self.count
+
+    async def increment(self) -> int:
+        """Increment the counter."""
+        self.count += 1
+        return self.count
+
+    async def decrement(self) -> int:
+        """Decrement the counter."""
+        self.count -= 1
+        return self.count
+
+    async def reset(self) -> int:
+        """Reset the counter."""
+        self.count = 0
+        return self.count
+
+    def get_name(self) -> str:
+        """Get the service name (sync method)."""
+        return self.name
+
+
+class MixedService(RpcTarget):
+    """Service that overrides call() for some methods but uses auto-dispatch for others."""
+
+    async def auto_method(self) -> str:
+        """This uses automatic dispatch."""
+        return "auto"
+
+    async def call(self, method: str, args: list[Any]) -> Any:
+        """Custom implementation that handles some methods manually."""
+        # Handle specific method manually
+        if method == "manual_method":
+            return "manual"
+
+        # Fall back to automatic dispatch for other methods
+        return await super().call(method, args)
+
+
+@pytest.fixture
+async def auto_server():
+    """Create and start a test server with automatic dispatch."""
+    config = ServerConfig(host="127.0.0.1", port=18081)
+    server_instance = Server(config)
+
+    # Register capabilities
+    server_instance.register_capability(0, AutoCalculator())
+    server_instance.register_capability(1, StatefulService())
+    server_instance.register_capability(2, MixedService())
+
+    await server_instance.start()
+
+    yield server_instance
+
+    await server_instance.stop()
+
+
+@pytest.fixture
+async def auto_client():
+    """Create a test client."""
+    config = ClientConfig(url="http://127.0.0.1:18081/rpc/batch", timeout=5.0)
+    client_instance = Client(config)
+
+    yield client_instance
+
+    await client_instance.close()
+
+
+@pytest.mark.asyncio
+class TestAutomaticMethodDispatch:
+    """Tests for automatic method dispatch."""
+
+    async def test_async_method_call(
+        self, auto_server: Server, auto_client: Client
+    ) -> None:
+        """Test calling an async method automatically."""
+        await asyncio.sleep(0.1)
+
+        result = await auto_client.call(0, "add", [5, 3])
+        assert result == 8
+
+    async def test_sync_method_call(
+        self, auto_server: Server, auto_client: Client
+    ) -> None:
+        """Test calling a sync method automatically."""
+        await asyncio.sleep(0.1)
+
+        result = await auto_client.call(0, "multiply", [6, 7])
+        assert result == 42
+
+    async def test_multiple_methods(
+        self, auto_server: Server, auto_client: Client
+    ) -> None:
+        """Test calling multiple methods."""
+        await asyncio.sleep(0.1)
+
+        result1 = await auto_client.call(0, "add", [10, 20])
+        result2 = await auto_client.call(0, "subtract", [50, 15])
+        result3 = await auto_client.call(0, "multiply", [3, 4])
+
+        assert result1 == 30
+        assert result2 == 35
+        assert result3 == 12
+
+    async def test_method_with_exception(
+        self, auto_server: Server, auto_client: Client
+    ) -> None:
+        """Test that exceptions in methods are properly propagated."""
+        await asyncio.sleep(0.1)
+
+        with pytest.raises(RpcError) as exc_info:
+            await auto_client.call(0, "divide", [10, 0])
+
+        # The ValueError gets wrapped in an RpcError
+        assert exc_info.value.code.value in ["internal", "bad_request"]
+
+    async def test_private_method_blocked(
+        self, auto_server: Server, auto_client: Client
+    ) -> None:
+        """Test that private methods (starting with _) are not accessible."""
+        await asyncio.sleep(0.1)
+
+        with pytest.raises(RpcError) as exc_info:
+            await auto_client.call(0, "_private_method", [])
+
+        assert exc_info.value.code.value == "not_found"
+        assert "not found" in exc_info.value.message.lower()
+
+    async def test_nonexistent_method(
+        self, auto_server: Server, auto_client: Client
+    ) -> None:
+        """Test that calling a non-existent method raises an error."""
+        await asyncio.sleep(0.1)
+
+        with pytest.raises(RpcError) as exc_info:
+            await auto_client.call(0, "nonexistent_method", [])
+
+        assert exc_info.value.code.value == "not_found"
+
+    async def test_concurrent_auto_calls(
+        self, auto_server: Server, auto_client: Client
+    ) -> None:
+        """Test concurrent calls with automatic dispatch."""
+        await asyncio.sleep(0.1)
+
+        # Make multiple concurrent calls
+        tasks = [auto_client.call(0, "add", [i, i + 1]) for i in range(10)]
+
+        results = await asyncio.gather(*tasks)
+
+        # Verify results
+        for i, result in enumerate(results):
+            assert result == i + (i + 1)
+
+
+@pytest.mark.asyncio
+class TestStatefulAutoDispatch:
+    """Tests for stateful services with automatic dispatch."""
+
+    async def test_stateful_operations(
+        self, auto_server: Server, auto_client: Client
+    ) -> None:
+        """Test stateful operations maintain state correctly."""
+        await asyncio.sleep(0.1)
+
+        # Increment multiple times
+        result1 = await auto_client.call(1, "increment", [])
+        assert result1 == 1
+
+        result2 = await auto_client.call(1, "increment", [])
+        assert result2 == 2
+
+        # Decrement
+        result4 = await auto_client.call(1, "decrement", [])
+        assert result4 == 1
+
+        # Reset
+        result5 = await auto_client.call(1, "reset", [])
+        assert result5 == 0
+
+    async def test_sync_method_on_stateful(
+        self, auto_server: Server, auto_client: Client
+    ) -> None:
+        """Test calling sync methods on stateful services."""
+        await asyncio.sleep(0.1)
+
+        result = await auto_client.call(1, "get_name", [])
+        assert result == "StatefulService"
+
+
+@pytest.mark.asyncio
+class TestMixedDispatch:
+    """Tests for mixed manual/automatic dispatch."""
+
+    async def test_manual_method(
+        self, auto_server: Server, auto_client: Client
+    ) -> None:
+        """Test manually dispatched method."""
+        await asyncio.sleep(0.1)
+
+        result = await auto_client.call(2, "manual_method", [])
+        assert result == "manual"
+
+    async def test_auto_method(self, auto_server: Server, auto_client: Client) -> None:
+        """Test automatically dispatched method."""
+        await asyncio.sleep(0.1)
+
+        result = await auto_client.call(2, "auto_method", [])
+        assert result == "auto"
+
+
+@pytest.mark.asyncio
+class TestDirectInvocation:
+    """Tests for direct invocation of RpcTarget methods (unit tests)."""
+
+    async def test_direct_call_async_method(self) -> None:
+        """Test calling methods directly via call()."""
+        calc = AutoCalculator()
+
+        result = await calc.call("add", [5, 3])
+        assert result == 8
+
+    async def test_direct_call_sync_method(self) -> None:
+        """Test calling sync methods directly via call()."""
+        calc = AutoCalculator()
+
+        result = await calc.call("multiply", [6, 7])
+        assert result == 42
+
+    async def test_direct_call_private_blocked(self) -> None:
+        """Test that private methods are blocked when called directly."""
+        calc = AutoCalculator()
+
+        with pytest.raises(RpcError) as exc_info:
+            await calc.call("_private_method", [])
+
+        assert exc_info.value.code.value == "not_found"
+
+    async def test_direct_get_property(self) -> None:
+        """Test getting properties directly."""
+        service = StatefulService()
+        service.count = 42
+
+        result = await service.get_property("count")
+        assert result == 42
+
+    async def test_direct_get_private_property_blocked(self) -> None:
+        """Test that private properties are blocked."""
+        service = StatefulService()
+
+        with pytest.raises(RpcError) as exc_info:
+            await service.get_property("_internal_state")
+
+        assert exc_info.value.code.value == "not_found"
+
+    async def test_get_property_method_blocked(self) -> None:
+        """Test that methods are not accessible as properties."""
+        service = StatefulService()
+
+        with pytest.raises(RpcError) as exc_info:
+            await service.get_property("increment")
+
+        assert exc_info.value.code.value == "not_found"


### PR DESCRIPTION
I find the typescript usage of `RpcTarget` to be significantly more ergonomic.

```ts
class MyApiServer extends RpcTarget {
  hello(name) {
    return `Hello, ${name}!`
  }
}
```

In their usage, all you really need to do is extend from `RpcTarget` and define some methods. Every non-private method is then callable from the RPC connection. I thought it'd be nice to do the same thing here. So instead this

```py
class MyApiServer(RpcTarget):
  async def call(self, method: str, args: list[Any]) -> Any:
    match method:
      case "hello":
        return f"Hello, {args[0]}"
```

we could just implement it as

```py
class MyApiServer(RpcTarget):
  def hello(self, name: str) -> str:
    return f"Hello, {name}"
```

The nice thing about my implementation approach is that if you already have a definition of `call`, it'll continue to work exactly the same as it does today. You just are no longer _required_ to implement call because there's a default implementation. 

--- 

There's a few longer term things that I think would be nice to do
1. Make the client interface seem more like it's a regular object (instead of the `call` method)
2. Make the target Pydantic compatible to ensure inputs/outputs can be validated